### PR TITLE
Bootstrap: docs + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+
+name: CI
+on:
+pull_request:
+push:
+branches: [ main ]
+jobs:
+ci:
+runs-on: ubuntu-latest
+steps:
+- uses: actions/checkout@v4
+- uses: actions/setup-node@v4
+with:
+node-version: 20
+- run: npm ci
+- run: echo "Docs-only bootstrap. App scaffold will be added in the next PR."
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+- **Branching:** feature branches from `main`, small PRs.
+- **Commits:** Conventional Commits (feat:, fix:, docs:, chore: …).
+- **Code style:** Prettier default; ESLint in scaffold PR.
+- **Tests:** Add/maintain unit + e2e (scaffold PR will wire CI).
+- **Docs:** Update `docs/**` when API/contracts change.
+
+## PR checklist
+- [ ] Matches spec/design
+- [ ] Adds/updates tests as needed
+- [ ] Keeps public APIs documented

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# NanoBananaPeel
+# BananaPeel
+
+Manual edit of Nano Banana generated images. This tool lets users directly edit AI images by segmenting elements into layers, then moving/scaling/rotating/reordering them—without prompt wrangling.
+
+## Packages (coming next PR)
+- `packages/web`: Konva/Fabric front end
+- `packages/server`: Express/TS segmentation API stubs
+
+## Docs
+- See `docs/spec.md`, `docs/design.md`, `docs/test-plan.md`, `docs/api.md`
+
+## Development (to be expanded in scaffold PR)
+- Node 20+
+- `npm ci`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,81 @@
+API & Data Contracts — BananaPeel
+Coordinate System
+
+All boxes/points are normalized to the original image size unless noted.
+
+Endpoints
+POST /segment
+
+Runs segmentation on an image region/prompt and returns a mask.
+
+Request
+
+{
+  "imageId": "string",
+  "imageUrl": "string (optional)",
+  "prompt": {
+    "type": "box|points",
+    "box": [0.10, 0.12, 0.45, 0.82],
+    "points": [[0.33,0.52,1],[0.35,0.49,0]]
+  },
+  "options": {
+    "return": "rle|png",
+    "previewScale": 1.0
+  }
+}
+
+
+Response (RLE example)
+
+{
+  "mask": { "format": "rle", "size": [H, W], "counts": "<coco-rle>" },
+  "bbox": [x, y, w, h],
+  "score": 0.97,
+  "layerName": "segment_1"
+}
+
+
+Response (PNG alpha example)
+
+{
+  "mask": { "format": "png", "width": W, "height": H, "data": "data:image/png;base64,..." },
+  "bbox": [x, y, w, h],
+  "score": 0.95,
+  "layerName": "segment_1"
+}
+
+
+Implementation note: a temporary stub response may use "format": "bbox" with just bbox for initial wiring.
+
+POST /nl/plan
+
+Converts a natural-language instruction into a list of canvas actions.
+
+Request
+
+{
+  "imageId": "img_123",
+  "utterance": "cut out the person and put them in front of the car",
+  "sceneSummary": { "layers": [] },
+  "mode": "plan_and_ground"
+}
+
+
+Response
+
+{
+  "actions": [
+    {"op":"segment","target":{"query":"person"},"prompt":{"type":"box","box":[0.18,0.22,0.36,0.78]},"result_layer_name":"person_1"},
+    {"op":"segment","target":{"query":"car"},"prompt":{"type":"box","box":[0.40,0.48,0.88,0.86]},"result_layer_name":"car_1"},
+    {"op":"reorder","layer":"person_1","zAction":"bringInFrontOf","relativeTo":"car_1"}
+  ]
+}
+
+Scene JSON (draft)
+{
+  "image": { "id": "img_123", "width": 1920, "height": 1080 },
+  "layers": [
+    { "id": "person_1", "type":"image-mask", "source":"img_123", "mask": { "format":"rle", "size":[H,W], "counts":"..." }, "transform": { "tx":120, "ty":-30, "scale":1.05, "rot":0 }, "zIndex": 3 }
+  ],
+  "history": []
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,38 @@
+System Design — BananaPeel
+A) Context & Goals
+
+Summary diagram (boxes & arrows)
+
+B) Detailed Components
+
+Client: canvas engine, mask application, transforms, z-order
+
+LLM Orchestrator: prompt templates, grounding strategy
+
+Segmentation: model choice, hardware, batching, warmup
+
+API: endpoints, auth, rate limits
+
+Data: object store layout, TTLs
+
+C) Flows
+
+NL → plan → ground → SAM → actions → apply
+
+Manual box/points → SAM → mask → layer
+
+D) Performance Planning
+
+Budget per step (ms)
+
+Caching layers/masks; RLE vs. PNG payloads
+
+E) Security & Privacy
+
+Data paths; encryption; logging policy; PII
+
+F) Ops
+
+CI/CD, canary, blue/green
+
+Observability (metrics, traces, logs)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,109 @@
+# Project Spec — BananaPeel
+
+## 1) Overview
+- **Project name:** BananaPeel
+- **One-liner:** Manual edit of Nano Banana generated images
+- **Problem statement:** Do you ever get an AI generated image that's almost there, but takes forever to describe the last bit of changes by prompt? This tool allows you to edit the image directly, saving you from the prompt hell.
+- **Success metrics (quantitative):** n/a
+- **Out of scope / Non-goals:** support manual edit of images only, do not deal with previous generation or the post processing of image of image.
+
+## 2) Users & Use Cases
+- **Personas:** non professional designer
+- **Primary jobs-to-be-done:** (fill)
+- **Top scenarios / stories:** (fill)
+
+## 3) Requirements
+### Functional
+- Import image
+- User prompts (NL + clicks/boxes)
+- AI segmentation (server or client)
+- Create layers from masks
+- Move/scale/rotate
+- Z-order control
+- Export (PNG with alpha / PSD-like JSON)
+- Undo/redo, history
+
+### Non-Functional (NFRs)
+- **Latency targets:** e.g., first mask < 1.5s p95
+- **Accuracy targets:** IoU vs. human mask > X
+- **Reliability:** uptime, retries
+- **Privacy/Security:** image retention policy, PII handling
+- **Browser support:** desktop Chrome/Edge/Safari, touch support
+- **Accessibility:** keyboard ops; ARIA for controls
+
+### Constraints & Assumptions
+- Client can run WebGPU? Fallback to server?
+- Max image size; memory limits
+- Allowed third-party services (if any)
+
+## 4) User Experience
+- **Flows:** (import → prompt → preview → refine → export)
+- **Wireframes/links:** (paste Figma link)
+- **Empty/Loading/Error states:** (fill)
+
+## 5) API & Data Contracts
+### Action DSL (client)
+```json
+{
+  "actions": [
+    {"op":"segment","target":{"query":"<string>"},"prompt":{"type":"box|points|auto","box":[x0,y0,x1,y1],"points":[[x,y,label],...]},"result_layer_name":"<id>"},
+    {"op":"transform","layer":"<id>","translate":[dx,dy],"scale":1.0,"rotate_deg":0},
+    {"op":"reorder","layer":"<id>","zAction":"bringToFront|sendToBack|bringInFrontOf","relativeTo":"<id>"}
+  ]
+}
+```
+
+
+/nl/plan request/response (see docs/api.md)
+
+/segment request/response (RLE/PNG mask; see docs/api.md)
+
+Scene JSON format (layers, masks, transforms) (fill)
+
+6) Architecture (Draft)
+
+Front end: Konva.js or Fabric.js, state store, history stack
+
+Orchestrator: LLM for planning + grounding
+
+Segmentation service: SAM (server), alternative: GrabCut/ISNet
+
+Storage: temp image blobs, signed URLs
+
+Telemetry: latency, errors, usage events
+
+7) Milestones & Deliverables
+
+M0: Spec sign-off
+
+M1: Thin slice (import → single mask via server → move/scale → export)
+
+M2: NL commands + grounding
+
+M3: Multi-object, z-order, undo/redo
+
+M4: Polishing, a11y, docs
+
+8) Acceptance Criteria
+
+Task A: “Cut out the person; put in front of the car.” completes in < Xs, visual check passes
+
+Task B: Background removal quality ≥ target IoU on test set
+
+API contracts stable and documented
+
+9) Risks & Mitigations
+
+WebGPU availability → server fallback
+
+Memory usage on large images → tiled processing
+
+Ambiguous NL commands → disambiguation UI
+
+10) Open Questions
+
+Which stack (Fabric vs. Konva)?
+
+Self-hosted vs. managed inference?
+
+Export formats (PSD? layered PNG?)

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,22 @@
+Test Plan — BananaPeel
+Levels
+
+Unit, Integration, E2E (playwright/cypress), Visual regression
+
+Golden Tasks (E2E)
+
+Person-in-front-of-car scenario
+
+Multi-object reorder
+
+Undo/redo stress
+
+Quality Gates
+
+Lint, typecheck, unit coverage ≥ X%
+
+E2E green on PR
+
+Datasets
+
+Public benchmark images + in-house set with expected masks (golden)


### PR DESCRIPTION
## Summary
- add top-level README and CONTRIBUTING guide for the BananaPeel project
- capture initial product spec, design, API, and test plan under docs/
- scaffold a placeholder CI workflow that installs dependencies and documents next steps

## Testing
- not run (docs and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d6f27a5fdc832c9f8d5246eab2f630