### PR TITLE
Guard Node CI steps behind package.json presence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Only run Node steps if a package.json exists
+      - name: Install deps
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm install
+
+      - name: Lint
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm run lint --if-present
+
+      - name: Build
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm run build --if-present
+
+      - name: Test
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm test -- --watch=false


### PR DESCRIPTION
## Summary
- replace the CI workflow to guard all Node-related commands behind a package.json existence check
- keep the Node 20 environment setup so repos with manifests can continue installing, linting, building, and testing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd75ea75c0832cb8a8706493af9a90